### PR TITLE
Only inject watched resources that are Grails artefacts

### DIFF
--- a/src/groovy/org/grails/plugin/platform/injection/InjectionImpl.groovy
+++ b/src/groovy/org/grails/plugin/platform/injection/InjectionImpl.groovy
@@ -86,26 +86,28 @@ class InjectionImpl implements Injection {
             log.debug "Applying injected methods to [${clazz}]"
         }
         def artefactType = grailsApplication.getArtefactType(clazz)
-        def type = GrailsNameUtils.getPropertyName(artefactType.type)
-        List<Closure> applicators = injectionsByArtefactType[type]
-        List<Closure> globalApplicators = injectionsByArtefactType['*']
+        if(artefactType) {
+            def type = GrailsNameUtils.getPropertyName(artefactType.type)
+            List<Closure> applicators = injectionsByArtefactType[type]
+            List<Closure> globalApplicators = injectionsByArtefactType['*']
 
-        if (log.debugEnabled) {
-            log.debug "Applying injected methods for artefact type [$type]"
-        }
-        for (a in applicators) {
-            // @todo do we need to clone always?
-            def builder = new InjectionBuilderMethodDelegate(clazz, artefactType, a, grailsApplication.mainContext)
-            def methodsToApply = builder.build()
-            applyMethodsTo(clazz, methodsToApply)
-        }
-        if (log.debugEnabled) {
-            log.debug "Applying injected methods for all artefact types"
-        }
-        for (a in globalApplicators) {
-            def builder = new InjectionBuilderMethodDelegate(clazz, artefactType, a, grailsApplication.mainContext)
-            def methodsToApply = builder.build()
-            applyMethodsTo(clazz, methodsToApply)
+            if (log.debugEnabled) {
+                log.debug "Applying injected methods for artefact type [$type]"
+            }
+            for (a in applicators) {
+                // @todo do we need to clone always?
+                def builder = new InjectionBuilderMethodDelegate(clazz, artefactType, a, grailsApplication.mainContext)
+                def methodsToApply = builder.build()
+                applyMethodsTo(clazz, methodsToApply)
+            }
+            if (log.debugEnabled) {
+                log.debug "Applying injected methods for all artefact types"
+            }
+            for (a in globalApplicators) {
+                def builder = new InjectionBuilderMethodDelegate(clazz, artefactType, a, grailsApplication.mainContext)
+                def methodsToApply = builder.build()
+                applyMethodsTo(clazz, methodsToApply)
+            }
         }
     }
     


### PR DESCRIPTION
Platform Core observes all plugins and responds to their onChange events. During this process it attempts to execute InjectionImpl.applyTo on the source of the onChange event. This can result in a NPE if the watched resource is not a Grails artefact:

```
2012-07-31 16:15:27,046 [FileSystemWatcher: files=#368 cl=java.net.URLClassLoader@560508be] ERROR plugins.AbstractGrailsPluginManager  - Plugin [springBatch:0.3] could not reload changes to file [/Users/john/workspace/grails-spring-batch/test/projects/spring-batch-ui-test/grails-app/batch/SimpleJobBatchConfig.groovy]: Cannot get property 'type' on null object
Message: Cannot get property 'type' on null object
   Line | Method
->>  89 | applyTo in org.grails.plugin.platform.injection.InjectionImpl
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
|   269 | doCall  in PlatformCoreGrailsPlugin$_closure9
^   680 | run . . in java.lang.Thread
```

This patch simply bypasses the applyTo on any classes that are not registered as Grails artefacts.
