### PR TITLE
Update src/groovy/org/grails/plugin/platform/events/EventsImpl.groovy

### DIFF
--- a/src/groovy/org/grails/plugin/platform/events/EventsImpl.groovy
+++ b/src/groovy/org/grails/plugin/platform/events/EventsImpl.groovy
@@ -75,7 +75,7 @@ class EventsImpl implements Events {
                 self.event(null, topic, data, pluginParam, callback)
             }
 
-            event { String topic, data = null, Map params = null, Closure callback = null ->
+            event { String topic, data = null, Map params = [:], Closure callback = null ->
                 if (pluginName) {
                     params = params ? pluginParam + params : pluginParam
                 }


### PR DESCRIPTION
made event method null safe for none-present params
e.g. event("myEvent", "myData")
