### PR TITLE
Fix link to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # This repository is defunct
 
-The Grails Platform Core plugin is now maintained at [http://github.com/grails-plugins/grails-platform-core/]().
+The Grails Platform Core plugin is now maintained at http://github.com/grails-plugins/grails-platform-core/.
 
 
 


### PR DESCRIPTION
The previous README pointed to the old repo under the Grailsrocks organization. Probably not terribly important though.
